### PR TITLE
Fix README punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ CVision is a desktop application written in PyQt6 + pyqtgraph used to:
 
 3. Select the type of measurement (Oxidation/Reduction).
 
-4. Load the data with the “Select data file” button..
+4. Load the data with the “Select data file” button.
 
 5. Optionally smooth the data (do not increase the window >15).
 


### PR DESCRIPTION
## Summary
- fix an extra period in the Using section of README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684924858ffc8325b0d1128d43340d0c