### PR TITLE
Fix README bash block

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ CVision is a desktop application written in PyQt6 + pyqtgraph used to:
    ```bash
    git clone https://github.com/StarGate3/cv-cyclic-voltammetry.git
    cd cv-cyclic-voltammetry
+   ```
 
 2. Create and activate a virtual environment:
     python -m venv venv


### PR DESCRIPTION
## Summary
- fix missing closing bash code block in the installation section of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684924b7fc7c83258e4343866507b641